### PR TITLE
chore: bump major versions of github actions in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Check for file changes
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
@@ -204,10 +204,10 @@ jobs:
           python-version: '3.11'
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
 
       - name: Cache uv dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/uv
           key: ${{ runner.os }}-uv-${{ hashFiles('backend/requirements.txt') }}
@@ -325,7 +325,7 @@ jobs:
 
       # OPTIMIZATION 1: Dependency Caching - npm
       - name: Cache npm dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('frontend/package-lock.json') }}
@@ -476,7 +476,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push backend image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./backend
           file: ./backend/Dockerfile
@@ -548,7 +548,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push frontend image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./frontend
           file: ./frontend/Dockerfile

--- a/.github/workflows/manual-rebuild.yml
+++ b/.github/workflows/manual-rebuild.yml
@@ -67,7 +67,7 @@ jobs:
       # ========================================
       - name: Build and Push Backend Image
         if: inputs.rebuild_scope == 'all' || inputs.rebuild_scope == 'backend-only'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./backend
           file: ./backend/Dockerfile
@@ -84,7 +84,7 @@ jobs:
       # ========================================
       - name: Build and Push Frontend Image
         if: inputs.rebuild_scope == 'all' || inputs.rebuild_scope == 'frontend-only'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./frontend
           file: ./frontend/Dockerfile

--- a/.github/workflows/security-auto-fix.yml
+++ b/.github/workflows/security-auto-fix.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check-changes.outputs.has_changes == 'true' && github.event.repository.fork == false
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |
@@ -254,7 +254,7 @@ jobs:
 
       - name: Create Pull Request for NPM fixes
         if: steps.npm-fix.outputs.has_changes == 'true' && github.event.repository.fork == false
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |


### PR DESCRIPTION
Bumps the major versions of github actions to their latest stable releases across `ci.yml`, `manual-rebuild.yml`, and `security-auto-fix.yml` workflows. This resolves node deprecation warnings and upgrades underlying runners.

---
*PR created automatically by Jules for task [11289634485641417176](https://jules.google.com/task/11289634485641417176) started by @gigahidjrikaaa*